### PR TITLE
Add support for sessionToken

### DIFF
--- a/src/main/java/com/perceptus/supers3t/S3Client.java
+++ b/src/main/java/com/perceptus/supers3t/S3Client.java
@@ -17,33 +17,34 @@ public class S3Client {
     public static final String DEFAULT_ENDPOINT = "s3-us-west-1.amazonaws.com";
     private static final Logger logger = LoggerFactory.getLogger(S3Client.class);
 
-    private static final Vertx vertx = Vertx.vertx();
+
 
     private final String awsAccessKey;
     private final String awsSecretKey;
+    private final String awsSessionToken;
 
     private final HttpClient client;
 
     public S3Client() {
-        this(vertx, null, null, DEFAULT_ENDPOINT);
+        this(null, null);
     }
 
     public S3Client(String accessKey, String secretKey) {
-        this(vertx, accessKey, secretKey, DEFAULT_ENDPOINT);
+        this(Vertx.vertx(), accessKey, secretKey, null, DEFAULT_ENDPOINT);
     }
 
-    public S3Client(String accessKey, String secretKey, String endpoint) {
-        this(vertx, accessKey, secretKey, endpoint);
+    public S3Client(String accessKey, String secretKey, String sessionToken, String endpoint) {
+        this(Vertx.vertx(), accessKey, secretKey, sessionToken, endpoint);
     }
 
-    public S3Client(Vertx vertx,
-                    String accessKey,
-                    String secretKey,
-                    String endpoint) {
+
+    public S3Client(Vertx vertx, String accessKey, String secretKey, String sessionToken, String endpoint) {
         awsAccessKey = accessKey;
         awsSecretKey = secretKey;
+        awsSessionToken = sessionToken;
 
         this.client = vertx.createHttpClient(new HttpClientOptions().setDefaultHost(endpoint));
+
     }
 
     // Direct call (async)
@@ -137,7 +138,8 @@ public class S3Client {
                 key,
                 httpRequest,
                 awsAccessKey,
-                awsSecretKey);
+                awsSecretKey,
+                awsSessionToken);
     }
 
     // create GET -> request Object
@@ -152,7 +154,8 @@ public class S3Client {
                 key,
                 httpRequest,
                 awsAccessKey,
-                awsSecretKey);
+                awsSecretKey,
+                awsSessionToken);
     }
 
     // create DELETE -> request Object
@@ -167,7 +170,8 @@ public class S3Client {
                 key,
                 httpRequest,
                 awsAccessKey,
-                awsSecretKey);
+                awsSecretKey,
+                awsSessionToken);
     }
 
     public void close() {

--- a/src/test/java/com/perceptus/supers3t/test/TestS3Client.java
+++ b/src/test/java/com/perceptus/supers3t/test/TestS3Client.java
@@ -31,6 +31,7 @@ public class TestS3Client {
 
     private static final String accessKey = "";
     private static final String secretKey = "";
+    private static final String sessionToken = "";
 
     private static final String testBucket = "Perceptus";
 
@@ -42,6 +43,7 @@ public class TestS3Client {
     @Before
     public void setUp() throws Exception {
         client = new S3Client(accessKey, secretKey);
+//        client = new S3Client(accessKey, secretKey, sessionToken, S3Client.DEFAULT_ENDPOINT);
     }
 
     /**


### PR DESCRIPTION
I use this library on ec2 using instance roles. AWS creates temporary
credentials in this case which require a sessionToken. I modified this
library to allow an optional sessionToken.

I also changed the default Vertx.vertx() creation to not use a static
initializer. This was causing multiple vertx instances to be created when
used in an existing vertx project.
